### PR TITLE
Fix Slovenian translations

### DIFF
--- a/build/translations.json
+++ b/build/translations.json
@@ -244,8 +244,8 @@
     "cancel": "Zrušiť"
   },
   "sl": {
-    "confirm": "හරි",
-    "cancel": "එපා"
+    "confirm": "Potrdi",
+    "cancel": "Zapri"
   },
   "sr": {
     "confirm": "У реду",


### PR DESCRIPTION
"sl" is the ISO 639-1 code for Slovenian (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). The commit fixes the translations for "confirm" and "cancel". 